### PR TITLE
Bug #1975 Correction

### DIFF
--- a/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/Full/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -1918,7 +1918,8 @@ function Editor::open(%this)
       EditorGui.init();
 
    %this.editorEnabled();
-   Canvas.setContent(EditorGui);   
+   Canvas.setContent(EditorGui);  
+   $isFirstPersonVar = true;
    EditorGui.syncCameraGui();
 }
 


### PR DESCRIPTION
The change was made to the function that is executed when entering the world editor. The boolean variable for first person shooter was set to true, since the camera always defaults to first person on entering the world editor. On setting this boolean variable to be true, the correct camera setting will always be displayed on entering the world editor. This does not affect other camera labels.